### PR TITLE
Pythia 6 generator interface

### DIFF
--- a/Generator/CMakeLists.txt
+++ b/Generator/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(BDSIMInterface)
 add_subdirectory(CepGenInterface)
 add_subdirectory(Common)
+add_subdirectory(Pythia6Interface)
 add_subdirectory(Pythia8Interface)
 set(lhecswlibs ${lhecswlibs} PARENT_SCOPE)

--- a/Generator/Pythia6Interface/CMakeLists.txt
+++ b/Generator/Pythia6Interface/CMakeLists.txt
@@ -1,0 +1,10 @@
+# look for Pythia 6
+find_package(Pythia6)
+if(NOT Pythia6_FOUND)
+  return()
+endif()
+
+lhecsw_build(Generator_Pythia6Interface
+    SOURCES src/*.cc
+    LIBRARIES DD4hep::DDG4 ${Pythia6_LIBRARIES}
+    HEADERS ${Pythia6_INCLUDE_DIRS})

--- a/Generator/Pythia6Interface/include/Pythia6EventGenerator.h
+++ b/Generator/Pythia6Interface/include/Pythia6EventGenerator.h
@@ -20,6 +20,7 @@
 #define Generator_Pythia6Interface_Pythia6EventGenerator_h
 
 #include <DDG4/Geant4InputAction.h>
+#include <HepMC3/HEPEVT_Wrapper_Runtime.h>
 
 #include "Generator/Common/include/HepMC3EventConverter.h"
 
@@ -38,6 +39,7 @@ public:
 
 private:
   const std::string filename_;
+  HepMC3::HEPEVT_Wrapper_Runtime hepevt_wrapper_;
   HepMC3EventConverter hepmc_converter_;
 };
 

--- a/Generator/Pythia6Interface/include/Pythia6EventGenerator.h
+++ b/Generator/Pythia6Interface/include/Pythia6EventGenerator.h
@@ -1,0 +1,44 @@
+/*
+ *  LHeC offline simulation and reconstruction software
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef Generator_Pythia6Interface_Pythia6EventGenerator_h
+#define Generator_Pythia6Interface_Pythia6EventGenerator_h
+
+#include <DDG4/Geant4InputAction.h>
+
+#include "Generator/Common/include/HepMC3EventConverter.h"
+
+class Pythia6EventGenerator : public dd4hep::sim::Geant4EventReader {
+public:
+  explicit Pythia6EventGenerator(const std::string&);
+  virtual ~Pythia6EventGenerator() = default;
+
+  using Particles = dd4hep::sim::Geant4InputAction::Particles;
+  using Vertices = dd4hep::sim::Geant4InputAction::Vertices;
+
+  EventReaderStatus moveToEvent(int event_number) override;
+  inline EventReaderStatus skipEvent() override { return EVENT_READER_OK; }
+  EventReaderStatus readParticles(int event_number, Vertices& vertices, Particles& particles) override;
+  EventReaderStatus setParameters(std::map<std::string, std::string>& parameters) override;
+
+private:
+  const std::string filename_;
+  HepMC3EventConverter hepmc_converter_;
+};
+
+#endif

--- a/Generator/Pythia6Interface/include/Pythia6Interface.h
+++ b/Generator/Pythia6Interface/include/Pythia6Interface.h
@@ -1,0 +1,38 @@
+/*
+ *  LHeC offline simulation and reconstruction software
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef Generator_Pythia6Interface_Pythia6Interface_h
+#define Generator_Pythia6Interface_Pythia6Interface_h
+
+extern "C" {
+extern int pychge_(int&);
+extern void pyexec_();
+extern void pygive_(const char*, int);
+extern void pyinit_(const char*, const char*, const char*, double*, int, int, int);
+}
+
+namespace pythia6 {
+  inline int pychge(int pdgid) { return pychge_(pdgid); }
+  inline void pyexec() { pyexec_(); }
+  inline void pygive(const std::string& str) { pygive_(str.data(), str.length()); }
+  inline void pyinit(const std::string& frame, const std::string& beam, const std::string& target, double win) {
+    pyinit_(frame.data(), beam.data(), target.data(), &win, frame.length(), beam.length(), target.length());
+  }
+}  // namespace pythia6
+
+#endif

--- a/Generator/Pythia6Interface/include/Pythia6Interface.h
+++ b/Generator/Pythia6Interface/include/Pythia6Interface.h
@@ -23,6 +23,7 @@ extern "C" {
 extern int pychge_(int&);
 extern void pyexec_();
 extern void pygive_(const char*, int);
+extern void pyhepc_(int&);
 extern void pyinit_(const char*, const char*, const char*, double*, int, int, int);
 }
 
@@ -30,6 +31,7 @@ namespace pythia6 {
   inline int pychge(int pdgid) { return pychge_(pdgid); }
   inline void pyexec() { pyexec_(); }
   inline void pygive(const std::string& str) { pygive_(str.data(), str.length()); }
+  inline void pyhepc(int mconv) { pyhepc_(mconv); }
   inline void pyinit(const std::string& frame, const std::string& beam, const std::string& target, double win) {
     pyinit_(frame.data(), beam.data(), target.data(), &win, frame.length(), beam.length(), target.length());
   }

--- a/Generator/Pythia6Interface/src/Pythia6EventGenerator.cc
+++ b/Generator/Pythia6Interface/src/Pythia6EventGenerator.cc
@@ -1,0 +1,73 @@
+/*
+ *  LHeC offline simulation and reconstruction software
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <DDG4/Factories.h>
+#include <DDG4/Geant4InputAction.h>
+#include <HepMC3/HEPEVT_Wrapper.h>
+
+#include "Common/include/StringUtils.h"
+#include "Generator/Pythia6Interface/include/Pythia6EventGenerator.h"
+#include "Generator/Pythia6Interface/include/Pythia6Interface.h"
+
+using EventReaderStatus = dd4hep::sim::Geant4EventReader::EventReaderStatus;
+using PropertyMask = dd4hep::detail::ReferenceBitMask<int>;
+
+Pythia6EventGenerator::Pythia6EventGenerator(const std::string& filename)
+    : dd4hep::sim::Geant4EventReader(filename), filename_(filename) {
+  hepmc_converter_.particle_properties_getter = [=](int pdgid) {
+    HepMC3EventConverter::ParticleProperties props;
+    props.charge = pythia6::pychge(pdgid);
+    return props;
+  };
+}
+
+EventReaderStatus Pythia6EventGenerator::moveToEvent(int) { return EVENT_READER_OK; }
+
+EventReaderStatus Pythia6EventGenerator::readParticles(int, Vertices& vertices, Particles& particles) {
+  pythia6::pyexec();
+  HepMC3::GenEvent hepmc_evt(HepMC3::Units::GEV, HepMC3::Units::MM);
+  if (!HepMC3::HEPEVT_Wrapper::HEPEVT_to_GenEvent(&hepmc_evt))
+    dd4hep::except(__PRETTY_FUNCTION__, "Failed to convert Pythia 8 event into an HepMC3 event.");
+
+  if (hepmc_converter_.convert(hepmc_evt, vertices, particles))
+    return EVENT_READER_OK;
+  return EVENT_READER_IO_ERROR;
+}
+
+EventReaderStatus Pythia6EventGenerator::setParameters(std::map<std::string, std::string>& parameters) {
+  std::list<std::string> pre_commands, post_commands;
+  _getParameterValue(parameters, "Commands", pre_commands, pre_commands);
+  _getParameterValue(parameters, "PostCommands", post_commands, post_commands);
+
+  if (!filename_.empty())  // read a commands input file
+    if (const auto tokens = utils::split(filename_, '|', true); tokens.size() > 1) {
+      std::ifstream file(tokens.at(1));
+      std::string line;
+      while (std::getline(file, line))
+        pythia6::pygive(line);
+    }
+  for (const auto& cmd : pre_commands)  // steer the pre-initialisation parameters
+    pythia6::pygive(cmd);
+  pythia6::pyinit("3MOM", "p", "e-", 0. /* will be computed automatically from beams momenta */);
+  for (const auto& cmd : post_commands)  // steer the post-initialisation parameters
+    pythia6::pygive(cmd);
+
+  return EVENT_READER_OK;
+}
+
+DECLARE_GEANT4_EVENT_READER(Pythia6EventGenerator)  // add to the factory

--- a/Generator/Pythia6Interface/src/Pythia6EventGenerator.cc
+++ b/Generator/Pythia6Interface/src/Pythia6EventGenerator.cc
@@ -18,7 +18,7 @@
 
 #include <DDG4/Factories.h>
 #include <DDG4/Geant4InputAction.h>
-#include <HepMC3/HEPEVT_Wrapper.h>
+#include <HepMC3/HEPEVT_Helpers.h>
 
 #include "Common/include/StringUtils.h"
 #include "Generator/Pythia6Interface/include/Pythia6EventGenerator.h"
@@ -27,8 +27,15 @@
 using EventReaderStatus = dd4hep::sim::Geant4EventReader::EventReaderStatus;
 using PropertyMask = dd4hep::detail::ReferenceBitMask<int>;
 
+extern "C" {
+extern HepMC3::HEPEVT_Templated<4000, double> hepevt_;
+}
+
 Pythia6EventGenerator::Pythia6EventGenerator(const std::string& filename)
     : dd4hep::sim::Geant4EventReader(filename), filename_(filename) {
+  hepevt_wrapper_.set_hepevt_address((char*)&hepevt_);
+  hepevt_wrapper_.set_max_number_entries(hepevt_.nevhep);
+  hepevt_wrapper_.zero_everything();
   hepmc_converter_.particle_properties_getter = [=](int pdgid) {
     HepMC3EventConverter::ParticleProperties props;
     props.charge = pythia6::pychge(pdgid);
@@ -40,9 +47,18 @@ EventReaderStatus Pythia6EventGenerator::moveToEvent(int) { return EVENT_READER_
 
 EventReaderStatus Pythia6EventGenerator::readParticles(int, Vertices& vertices, Particles& particles) {
   pythia6::pyexec();
+  dd4hep::printout(dd4hep::DEBUG, __PRETTY_FUNCTION__, "Finished running the PYEXEC event generation subroutine.");
+  pythia6::pyhepc(1);
+  dd4hep::printout(dd4hep::DEBUG, __PRETTY_FUNCTION__, "Finished running the PYHEPC conversion subroutine.");
+  {
+    std::ostringstream hepevt_os;
+    hepevt_wrapper_.print_hepevt(hepevt_os);
+    dd4hep::printout(dd4hep::DEBUG, __PRETTY_FUNCTION__, "HEPEVT event content:\n%s", hepevt_os.str().c_str());
+  }
   HepMC3::GenEvent hepmc_evt(HepMC3::Units::GEV, HepMC3::Units::MM);
-  if (!HepMC3::HEPEVT_Wrapper::HEPEVT_to_GenEvent(&hepmc_evt))
+  if (!hepevt_wrapper_.HEPEVT_to_GenEvent(&hepmc_evt))
     dd4hep::except(__PRETTY_FUNCTION__, "Failed to convert Pythia 8 event into an HepMC3 event.");
+  dd4hep::printout(dd4hep::DEBUG, __PRETTY_FUNCTION__, "HepMC3 conversion done.");
 
   if (hepmc_converter_.convert(hepmc_evt, vertices, particles))
     return EVENT_READER_OK;

--- a/cmake/FindPythia6.cmake
+++ b/cmake/FindPythia6.cmake
@@ -1,0 +1,20 @@
+# Locate Pythia6 library
+# in a directory defined via Pythia6_DIR/PYTHIA6 environment variables
+#
+# Defines:
+#  Pythia6_FOUND
+#  Pythia6_LIBRARIES
+
+set(Pythia6_DIRS $ENV{Pythia6_DIR} $ENV{PYTHIA6})
+
+find_library(Pythia6_LIBRARY NAMES pythia6
+             HINTS ${Pythia6_DIRS} PATH_SUFFIXES lib lib64 build/lib)
+
+set(Pythia6_LIBRARIES ${Pythia6_LIBRARY})
+
+# handle the QUIETLY and REQUIRED arguments and set Pythia6_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Pythia6 DEFAULT_MSG Pythia6_LIBRARIES)
+
+mark_as_advanced(Pythia6_FOUND Pythia6_LIBRARIES)

--- a/test/LHeD_Pythia6_event.py
+++ b/test/LHeD_Pythia6_event.py
@@ -1,0 +1,86 @@
+"""
+
+   Run simulation using Pythia 8 event generation
+
+   @author  L.Forthomme
+   @version 1.0
+
+"""
+from __future__ import absolute_import, unicode_literals
+import logging
+
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def run():
+    import os
+    import DDG4
+    from DDG4 import OutputLevel as Output
+    import LHeD
+
+    DDG4.Core.setPrintFormat(str("%-32s %6s %s"))
+
+    lhed = LHeD.LHeD()
+    geant4 = lhed.geant4
+    kernel = lhed.kernel
+
+    lhed.loadGeometry()
+    geant4.printDetectors()
+    # Configure UI
+    #geant4.setupCshUI(vis=True)
+    #geant4.setupUI(typ='qt', vis=True)
+    geant4.setupUI(vis=False)
+    lhed.setupField(quiet=False)
+    DDG4.importConstants(kernel.detectorDescription(), debug=False)
+
+    #prt = DDG4.EventAction(kernel, 'Geant4ParticlePrint/ParticlePrint')
+    #prt.OutputLevel = Output.WARNING
+    #prt.OutputType = 3  # Print both: table and tree
+    #kernel.eventAction().adopt(prt)
+
+    geant4.setupROOTOutput('RootOutput', 'output.root')
+
+    gen = DDG4.GeneratorAction(kernel, 'Geant4InputAction/Input')
+    gen.Input = 'Pythia6EventGenerator'
+    gen.OutputLevel = Output.DEBUG
+    gen.Parameters = dict(
+        Commands = [
+            'P(1,3) = 7000d0',  # proton beam
+            'P(2,3) = -50d0',   # electron target
+            'MSTP(11) = 1',     # photon-inside-electron
+            'MSUB(58) = 1',     # gamma gamma -> l+ l-
+            #'CKIN(3) = 50d0',
+        ],
+    )
+    geant4.buildInputStage([gen], output_level=Output.DEBUG)
+
+    # Merge all existing interaction records
+    #merger = DDG4.GeneratorAction(kernel, 'Geant4InteractionMerger/InteractionMerger')
+    #merger.enableUI()
+    #kernel.generatorAction().adopt(merger)
+
+    part = DDG4.GeneratorAction(kernel, 'Geant4ParticleHandler/ParticleHandler')
+    kernel.generatorAction().adopt(part)
+    part.enableUI()
+
+    lhed.setupDetectors()
+    # Now build the physics list:
+    lhed.setupPhysics('QGSP_BERT')
+    lhed.test_config()
+
+    #scan = DDG4.SteppingAction(kernel, 'Geant4MaterialScanner/MaterialScan')
+    #kernel.steppingAction().adopt(scan)
+
+    #kernel.configure()
+    #kernel.initialize()
+    kernel.NumEvents = 10
+
+    kernel.run()
+    kernel.terminate()
+    logger.info('End of run. Terminating .......')
+    logger.info('TEST_PASSED')
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
This PR introduces a new `Geant4EventReader`-derivative for the generation of unweighted events using Pythia 6.
It relies on a first conversion of the generated event content to a `HEPEVT` memory block, before using the HepMC 3 `HEPEVT`-to-HepMC event converter.