### PR TITLE
Generator: simplification of CepGen steering through intermediate python parameter object

### DIFF
--- a/Generator/CepGenInterface/CMakeLists.txt
+++ b/Generator/CepGenInterface/CMakeLists.txt
@@ -3,8 +3,10 @@ find_package(CepGen)
 if(NOT CepGen_FOUND OR NOT HepMC3_FOUND)
   return()
 endif()
+find_package(nlohmann_json REQUIRED)
 
 lhecsw_build(Generator_CepGenInterface
+    SOURCES src/*.cc
     PLUGINS_SOURCES plugins/CepGen*.cc
-    LIBRARIES Gaudi::GaudiAlgLib ${CepGen_LIBRARIES} ${HEPMC3_LIBRARIES}
+    LIBRARIES Gaudi::GaudiAlgLib ${CepGen_LIBRARIES} ${HEPMC3_LIBRARIES} nlohmann_json::nlohmann_json
     HEADERS ${CepGen_INCLUDE_DIRS} ${HEPMC3_INCLUDE_DIR})

--- a/Generator/CepGenInterface/include/ParametersListConverter.h
+++ b/Generator/CepGenInterface/include/ParametersListConverter.h
@@ -1,0 +1,40 @@
+/*
+ *  LHeC offline simulation and reconstruction software
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef Generator_CepGenInterface_ParametersListConverter_h
+#define Generator_CepGenInterface_ParametersListConverter_h
+
+#include <CepGen/Core/ParametersList.h>
+
+#include <nlohmann/json.hpp>
+
+namespace cepgen {
+  class ParametersListConverter {
+  public:
+    explicit ParametersListConverter(const std::string& json_file);
+
+    operator ParametersList() const { return plist_; }
+
+  private:
+    ParametersList parse(const nlohmann::json&);
+
+    ParametersList plist_;
+  };
+}  // namespace cepgen
+
+#endif

--- a/Generator/CepGenInterface/plugins/CepGenEventGenerator.cc
+++ b/Generator/CepGenInterface/plugins/CepGenEventGenerator.cc
@@ -30,6 +30,7 @@
 #include <CepGenAddOns/HepMC3Wrapper/HepMC3EventInterface.h>
 #include <GaudiAlg/GaudiTool.h>
 
+#include "Generator/CepGenInterface/include/ParametersListConverter.h"
 #include "Generator/Common/include/IHepMCProviderTool.h"
 
 class CepGenEventGenerator : public GaudiTool, virtual public IHepMCProviderTool {
@@ -37,7 +38,9 @@ public:
   explicit CepGenEventGenerator(const std::string& type, const std::string& name, const IInterface* parent)
       : GaudiTool(type, name, parent),
         verbosity_{this, "verbosity", static_cast<int>(cepgen::utils::Logger::get().level()), "CepGen verbosity"},
-        process_cmds_{this, "process", {}, "CepGen commands to define process"},
+        process_str_{this, "process", "{}", "CepGen commands to define process"},
+        extra_process_str_{
+            this, "extraProcessCommands", {}, "Additional CepGen string-type commands to define process"},
         modifiers_seq_{this, "modifiersSequence", {}, "Sequential list of CepGen modifier modules defining the chain"},
         outputs_seq_{this, "outputsSequence", {}, "Sequential list of CepGen output modules defining the chain"},
         modifiers_cmds_{this, "modifiers", {}, "CepGen modifier->commands to define modifiers chain"},
@@ -62,8 +65,9 @@ private:
   std::unique_ptr<cepgen::Generator> cepgen_;
   std::shared_ptr<HepMC3::GenCrossSection> xsec_;
 
-  Gaudi::Property<int> verbosity_;                           ///< CepGen module verbosity
-  Gaudi::Property<std::vector<std::string> > process_cmds_;  ///< CepGen commands to define process
+  Gaudi::Property<int> verbosity_;                                ///< CepGen module verbosity
+  Gaudi::Property<std::string> process_str_;                      ///< JSON dump of CepGen commands to define process
+  Gaudi::Property<std::vector<std::string> > extra_process_str_;  ///< Extra string CepGen commands to define process
   Gaudi::Property<std::vector<std::string> > modifiers_seq_, outputs_seq_;
   Gaudi::Property<std::map<std::string, std::vector<std::string> > > modifiers_cmds_;  ///< Modifiers chain
   Gaudi::Property<std::map<std::string, std::vector<std::string> > > outputs_cmds_;    ///< Outputs chain
@@ -78,8 +82,8 @@ StatusCode CepGenEventGenerator::initialize() {
   cepgen_.reset(new cepgen::Generator);
   xsec_.reset(new HepMC3::GenCrossSection);
 
-  cepgen::ParametersList plist_proc;
-  for (const auto& cmd : process_cmds_)
+  auto plist_proc = (cepgen::ParametersList)cepgen::ParametersListConverter(process_str_);
+  for (const auto& cmd : extra_process_str_)
     plist_proc.feed(cmd);
   info() << "CepGen process parameters:\n" << plist_proc;
   cepgen_->runParameters().setProcess(cepgen::ProcessFactory::get().build(plist_proc));

--- a/Generator/CepGenInterface/plugins/CepGenEventGenerator.cc
+++ b/Generator/CepGenInterface/plugins/CepGenEventGenerator.cc
@@ -41,10 +41,8 @@ public:
         process_str_{this, "process", "{}", "CepGen commands to define process"},
         extra_process_str_{
             this, "extraProcessCommands", {}, "Additional CepGen string-type commands to define process"},
-        modifiers_seq_{this, "modifiersSequence", {}, "Sequential list of CepGen modifier modules defining the chain"},
-        outputs_seq_{this, "outputsSequence", {}, "Sequential list of CepGen output modules defining the chain"},
-        modifiers_cmds_{this, "modifiers", {}, "CepGen modifier->commands to define modifiers chain"},
-        outputs_cmds_{this, "outputs", {}, "CepGen output->commands to define outputs chain"} {
+        modifiers_str_{this, "modifiers", "{}", "Sequential list of CepGen modifier modules defining the chain"},
+        outputs_str_{this, "outputs", "{}", "Sequential list of CepGen output modules defining the chain"} {
     cepgen::utils::Logger::get().setLevel(static_cast<cepgen::utils::Logger::Level>(verbosity_.value()));
   }
   virtual ~CepGenEventGenerator() = default;
@@ -68,9 +66,8 @@ private:
   Gaudi::Property<int> verbosity_;                                ///< CepGen module verbosity
   Gaudi::Property<std::string> process_str_;                      ///< JSON dump of CepGen commands to define process
   Gaudi::Property<std::vector<std::string> > extra_process_str_;  ///< Extra string CepGen commands to define process
-  Gaudi::Property<std::vector<std::string> > modifiers_seq_, outputs_seq_;
-  Gaudi::Property<std::map<std::string, std::vector<std::string> > > modifiers_cmds_;  ///< Modifiers chain
-  Gaudi::Property<std::map<std::string, std::vector<std::string> > > outputs_cmds_;    ///< Outputs chain
+  Gaudi::Property<std::string> modifiers_str_;
+  Gaudi::Property<std::string> outputs_str_;
 };
 
 DECLARE_COMPONENT(CepGenEventGenerator)
@@ -82,31 +79,21 @@ StatusCode CepGenEventGenerator::initialize() {
   cepgen_.reset(new cepgen::Generator);
   xsec_.reset(new HepMC3::GenCrossSection);
 
-  auto plist_proc = (cepgen::ParametersList)cepgen::ParametersListConverter(process_str_);
+  auto plist_proc = static_cast<cepgen::ParametersList>(cepgen::ParametersListConverter(process_str_));
   for (const auto& cmd : extra_process_str_)
     plist_proc.feed(cmd);
   info() << "CepGen process parameters:\n" << plist_proc;
   cepgen_->runParameters().setProcess(cepgen::ProcessFactory::get().build(plist_proc));
 
-  for (const auto& mod : modifiers_seq_)          // browse the sequential list of event modifier modules requested
-    if (modifiers_cmds_.value().count(mod) == 0)  // use default parameters for the module
-      cepgen_->runParameters().addModifier(cepgen::EventModifierFactory::get().build(mod));
-    else {  // parse the list of parameters fed by the user
-      cepgen::ParametersList plist_mod;
-      for (const auto& cmd : modifiers_cmds_.value().at(mod))
-        plist_mod.feed(cmd);
-      cepgen_->runParameters().addModifier(cepgen::EventModifierFactory::get().build(mod, plist_mod));
-    }
+  const auto plist_mods = static_cast<cepgen::ParametersList>(cepgen::ParametersListConverter(modifiers_str_));
+  for (const auto& mod : plist_mods.keysOf<cepgen::ParametersList>())  // browse the sequence of event modifier modules
+    cepgen_->runParameters().addModifier(
+        cepgen::EventModifierFactory::get().build(mod, plist_mods.get<cepgen::ParametersList>(mod)));
 
-  for (const auto& mod : outputs_seq_)          // browse the sequential list of output modules requested
-    if (outputs_cmds_.value().count(mod) == 0)  // use default parameters for the module
-      cepgen_->runParameters().addEventExporter(cepgen::EventExporterFactory::get().build(mod));
-    else {  // parse the list of parameters fed by the user
-      cepgen::ParametersList plist_out;
-      for (const auto& cmd : outputs_cmds_.value().at(mod))
-        plist_out.feed(cmd);
-      cepgen_->runParameters().addEventExporter(cepgen::EventExporterFactory::get().build(mod, plist_out));
-    }
+  const auto plist_outputs = static_cast<cepgen::ParametersList>(cepgen::ParametersListConverter(outputs_str_));
+  for (const auto& mod : plist_outputs.keysOf<cepgen::ParametersList>())  // browse the sequence of output modules
+    cepgen_->runParameters().addEventExporter(
+        cepgen::EventExporterFactory::get().build(mod, plist_outputs.get<cepgen::ParametersList>(mod)));
 
   info() << "CepGen parameters:\n" << cepgen_->runParameters();
   const auto xsec = cepgen_->computeXsection();

--- a/Generator/CepGenInterface/src/ParametersListConverter.cc
+++ b/Generator/CepGenInterface/src/ParametersListConverter.cc
@@ -1,0 +1,70 @@
+/*
+ *  LHeC offline simulation and reconstruction software
+ *  Copyright (C) 2024  Laurent Forthomme
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <CepGen/Core/Exception.h>
+
+#include "Generator/CepGenInterface/include/ParametersListConverter.h"
+
+using json = nlohmann::json;
+
+namespace cepgen {
+  ParametersListConverter::ParametersListConverter(const std::string& json_config)
+      : plist_(parse(json::parse(json_config))) {
+    CG_DEBUG("ParametersListConverter") << "Parsed parameters list: " << plist_ << ".";
+  }
+
+  ParametersList ParametersListConverter::parse(const json& config) {
+    ParametersList plist;
+    for (const auto& it : config.items()) {
+      const auto& key = it.key();
+      const auto& val = it.value();
+      if (val.is_boolean())
+        plist.set(key, val.template get<bool>());
+      else if (val.is_number_unsigned())
+        plist.set<unsigned long long>(key, val.template get<unsigned>());
+      else if (val.is_number_integer())
+        plist.set(key, val.template get<int>());
+      else if (val.is_number_float())
+        plist.set<double>(key, val.template get<float>());
+      else if (val.is_string())
+        plist.set(key, val.template get<std::string>());
+      else if (val.is_array()) {
+        if (val.empty()) {
+          CG_WARNING("ParametersListConverter:parse")
+              << "Cannot determine array type for key='" << key << "'. Array is empty.";
+          continue;
+        }
+        const auto& item = val.at(0);
+        if (item.is_number_unsigned())
+          plist.set(key, val.template get<std::vector<unsigned> >());
+        else if (item.is_number_integer())
+          plist.set(key, val.template get<std::vector<int> >());
+        else if (item.is_number_float()) {
+          const auto& vec = val.template get<std::vector<float> >();
+          std::vector<double> vec_dbl(vec.begin(), vec.end());
+          plist.set(key, vec_dbl);
+        } else if (item.is_string())
+          plist.set(key, val.template get<std::vector<std::string> >());
+      } else if (val.is_structured())
+        plist.set(key, parse(val.template get<json>()));
+      else
+        CG_ERROR("ParametersListConverter:parse") << "Unknown object with key='" << key << "'.";
+    }
+    return plist;
+  }
+}  // namespace cepgen

--- a/python/Generator/cepgenInterface_cff.py
+++ b/python/Generator/cepgenInterface_cff.py
@@ -3,8 +3,26 @@ from Configurables import CepGenEventGenerator
 from Configurables import HepMCToEDMConverter, SimG4PrimariesFromEdmTool
 
 
+class CepGenParameters(dict):
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+    def __init__(self, *args, **kwargs):
+        self.update(*args, **kwargs)
+        super(CepGenParameters, self).__init__(*args, **kwargs)
+
+    def __str__(self):
+        from json import dumps
+        return dumps(self)
+
+class CepGenModule(CepGenParameters):
+    def __init__(self, name, *args, **kwargs):
+        super(CepGenModule, self).__init__(*args, **kwargs)
+        self.mod_name = name
+
 cepgen = CepGenEventGenerator("CepGenEventGenerator",
-    process = [],
+    process = '',
     OutputLevel = INFO,
 )
 

--- a/test/LHeD_CepGen_event.py
+++ b/test/LHeD_CepGen_event.py
@@ -9,14 +9,15 @@ from SimG4.sim_cff import geantservice, geantsim
 from SimAlgos.digi_cff import digis
 
 
-cepgen.process = [
-    'name:lpair',
-    'kinematics/beam1id:2212',
-    'kinematics/beam2id:11',
-    'kinematics/beam1pz:7000.0',
-    'kinematics/beam2pz:50.0',
-    'kinematics/ptmin:10.0',
-]
+cepgen.process = str(CepGenModule('lpair',
+    kinematics = CepGenParameters(
+        beam1id = 2212,
+        beam2id = 11,
+        beam1pz = 7000.,
+        beam2pz = 50.,
+        ptmin = 20.,
+    ))
+)
 
 genalg = GenAlg("CepGen",
     SignalProvider = cepgen,

--- a/test/LHeD_CepGen_event.py
+++ b/test/LHeD_CepGen_event.py
@@ -16,8 +16,16 @@ cepgen.process = str(CepGenModule('lpair',
         beam1pz = 7000.,
         beam2pz = 50.,
         ptmin = 20.,
-    ))
-)
+    )
+))
+#cepgen.modifiers = str(CepGenParameters(
+#    pythia6 = CepGenParameters(),
+#))
+#cepgen.outputs = str(CepGenParameters(
+#    dump = CepGenParameters(
+#        printEvery = 10,
+#    ),
+#))
 
 genalg = GenAlg("CepGen",
     SignalProvider = cepgen,


### PR DESCRIPTION
This PR simplifies the steering of a CepGen-based event generation thanks to the JSON serialisation (embedded in a Python dictionary-derivative object) of all user-controlled parameters. This allows to reduce the user overhead of learning how to use text-based feeding of CepGen's `ParametersList` object.